### PR TITLE
Replace nonfunctional iframe with thumbnail link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 This book is a companion booklet of the Advanced Design Mooc. 
 [https://advanced-design-mooc.pharo.org](https://advanced-design-mooc.pharo.org)
 
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=3A6tLsf4-q0)" frameborder="0" allowfullscreen></iframe>
-
-
-
+[![Teaser MOOC "Advanced object oriented design and development with Pharo"](https://github.com/user-attachments/assets/90cb48dd-d28e-4086-8fb4-7fe6c9c6f1c3)](https://www.youtube.com/watch?v=3A6tLsf4-q0)
 
 It contains miniprojects that make you practice different design aspect.
 


### PR DESCRIPTION
GitHub flavored Markdown disallows `iframes` (see: https://github.github.com/gfm/#disallowed-raw-html-extension-). We therefore need to supply our own thumbnail and link to the video.